### PR TITLE
Table wrapping fixes

### DIFF
--- a/docs/software/java/conditions.mdx
+++ b/docs/software/java/conditions.mdx
@@ -68,7 +68,7 @@ The are a few comparison operators each with their own behavior. Below is a tabl
 ## Logical Operators
 What if we want to make a compound condition? Compare if one conditions is true and another false? Both true? Luckily our pal [George Boole](https://en.wikipedia.org/wiki/George_Boole) had us in mind when he crated the concept called [boolean algebra](https://en.wikipedia.org/wiki/Boolean_algebra). The fundamentals of boolean logic is three logical operator **NOT**, **AND**, and **OR**. Below are some "truth tables" which show the boolean output of comparing conditions using those logical operators.
 
-<div style={{ display: 'flex', justifyContent: 'space-around', fontSize: 15}}>
+<div style={{ display: 'flex', justifyContent: 'wrap', gap: 20, fontSize: 15}}>
     <table>
     <caption style={{textAlign: 'center', fontSize: 25}}> **NOT** </caption>
     <tr> <td> **Condition** </td> <td> **Output** </td> </tr>
@@ -96,7 +96,7 @@ What if we want to make a compound condition? Compare if one conditions is true 
 </div>
 Because our conditions return a `boolean` *(true/false)*, these same logical operators can be used in code to compare conditions with one another. The tables below shows the logical operations available in Java. Remember that each `true` or `false` below can be replace with a condition.
 
-<div style={{ display: 'flex', justifyContent: 'space-around', fontSize: 15}}>
+<div style={{ display: 'flex', justifyContent: 'wrap', gap: 20, fontSize: 15}}>
     <table>
     <caption style={{textAlign: 'center', fontSize: 25}}> **NOT** </caption>
     <tr>


### PR DESCRIPTION
Both of the "Logical Operator" tables had rendering issues on mobile devices, caused by using "space-around" as opposed to "wrap" with a set gap between tables. This should make fix the spacing on mobile devices without affecting standard viewing.